### PR TITLE
Fix non-file candidates containing path characters

### DIFF
--- a/readline-complete.el
+++ b/readline-complete.el
@@ -260,7 +260,6 @@ To disable ac-rlc for an application, add '(prompt ac-prefix-rlc-disable).")
 
 (defun ac-prefix-rlc-shell ()
   ;; If completing a filepath, as below. Otherwise just search for space
-  (message "rlc-candidates: %s" (rlc-candidates))
   (if (re-search-backward "[ /]\\([^ /]*\\)\\=" nil t)
       (match-beginning 1)))
 


### PR DESCRIPTION
This fixes an issue which manifests when completing non-file prefixes which contain slashes (e.g. "origin/master"). 

The present code will complete "origin/ma" as "origin/origin/master" (the candidate retains the full path); this selectively unpaths candidates if the full prefix (back to most recent whitespace) contains a slash.
