### PR TITLE
Fix non file paths

### DIFF
--- a/readline-complete.el
+++ b/readline-complete.el
@@ -221,9 +221,11 @@ rlc-attempts * rlc-timeout seconds.")
               finally (run-hooks 'rlc-no-readline-hook))
       (set-process-filter proc filt))))
 
+(defconst interpath-separator-regex "/[^ /]+")
+
 (defun unpath (candidates)
   "If the full prefix is pathed, unpath CANDIDATES based on the length of path."
-  (let ((n (- (length (split-string (full-prefix-chars) "/")) 1)))
+  (let ((n (- (length (split-string (full-prefix-chars) interpath-separator-regex)) 1)))
     (if (> n 0)
         (mapcar (lambda (candidate)
                   (unpath-nth candidate n)) candidates)
@@ -231,7 +233,8 @@ rlc-attempts * rlc-timeout seconds.")
 
 (defun unpath-nth (candidate n)
   "Unpath CANDIDATE at depth N."
-  (let ((split-candidate (split-string candidate "/")))
+  (message "unpathing candidate %s at depth %d" candidate n)
+  (let ((split-candidate (split-string candidate interpath-separator-regex)))
     (or (nth n split-candidate) candidate)))
 
 ;; Auto-Complete
@@ -260,7 +263,6 @@ To disable ac-rlc for an application, add '(prompt ac-prefix-rlc-disable).")
 
 (defun ac-prefix-rlc-shell ()
   ;; If completing a filepath, as below. Otherwise just search for space
-  (message "rlc-candidates: %s" (rlc-candidates))
   (if (re-search-backward "[ /]\\([^ /]*\\)\\=" nil t)
       (match-beginning 1)))
 


### PR DESCRIPTION
Fixed from previous request -- the issue was that matches with a final path separator (e.g. `folder/`) would cause failure.
