### PR TITLE
Fix (void-variable shell)

### DIFF
--- a/readline-complete.el
+++ b/readline-complete.el
@@ -276,10 +276,13 @@ To disable ac-rlc for an application, add '(prompt ac-prefix-rlc-disable).")
 
 ;;;###autoload
 (eval-after-load 'auto-complete
-  `(ac-define-source shell
-     '((candidates . rlc-candidates)
-       (prefix . ac-rlc-prefix-shell-dispatcher)
-       (requires . 0))))
+  ;; eval to avoid compiling. compiler needs ac-define-source macro
+  ;; definition loaded or else we get runtime error, but we want to keep
+  ;; installation of auto-complete optional
+  '(eval '(ac-define-source shell
+            '((candidates . rlc-candidates)
+              (prefix . ac-rlc-prefix-shell-dispatcher)
+              (requires . 0)))))
 
 ;; Company
 ;;


### PR DESCRIPTION
This happens when you compile readline.el in an emacs where
auto-complete has not been loaded, because ac-define-source is a macro,
and the compiler needs to know that or it treats it as a function. This
isn't the best fix, since some commonly used compilation tactics, like
emacs --batch --eval  '(byte-recompile-directory .. won't work. Until we
find something better.

Fixes github issue #12 
